### PR TITLE
change errors to defined errors for better error handling

### DIFF
--- a/bank/bank.go
+++ b/bank/bank.go
@@ -6,6 +6,15 @@ import (
 	"strconv"
 )
 
+var (
+	// ErrBankNotFound is returned by CardInfo function
+	// when bank not found for input card
+	ErrBankNotFound = errors.New("bank not found")
+	// ErrInvalidCard is returned by CardInfo function
+	// when card has invalid format
+	ErrInvalidCard = errors.New("card is not valid")
+)
+
 var bankCode = map[string]string{
 	"636214": "ayandeh",
 	"627412": "eghtesad-novin",
@@ -63,12 +72,12 @@ var bankCode = map[string]string{
 func CardInfo(card string) (string, error) {
 	matched, err := regexp.MatchString("^\\d{16}$", card)
 	if !matched || err != nil || !validateCard(card) {
-		return "", errors.New("data not valid")
+		return "", ErrInvalidCard
 	}
 
 	bank, ok := bankCode[card[0:6]]
 	if !ok {
-		return "", errors.New("bank not found")
+		return "", ErrBankNotFound
 	}
 
 	return bank, nil

--- a/bank/bank_test.go
+++ b/bank/bank_test.go
@@ -8,18 +8,19 @@ func TestCardInfo(t *testing.T) {
 		entry   string
 		want    string
 		wantErr bool
+		err     error
 	}{
-		{name: "not valid 1", entry: "62198610", want: "", wantErr: true},
-		{name: "not valid 2", entry: "603770asdfgbvcfg", want: "", wantErr: true},
-		{name: "not valid 3", entry: "dfgsdg", want: "", wantErr: true},
-		{name: "not valid 4", entry: "6219861034529008", want: "", wantErr: true},
+		{name: "not valid 1", entry: "62198610", want: "", wantErr: true, err: ErrInvalidCard},
+		{name: "not valid 2", entry: "603770asdfgbvcfg", want: "", wantErr: true, err: ErrInvalidCard},
+		{name: "not valid 3", entry: "dfgsdg", want: "", wantErr: true, err: ErrInvalidCard},
+		{name: "not valid 4", entry: "6219861034529008", want: "", wantErr: true, err: ErrInvalidCard},
 		{name: "keshavarzi", entry: "6037701689095443", want: "keshavarzi", wantErr: false},
 		{name: "saman", entry: "6219861034529007", want: "saman", wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := CardInfo(tt.entry)
-			if (err != nil) != tt.wantErr {
+			if (!tt.wantErr && err != nil) || tt.err != err {
 				t.Errorf("CardInfo() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}

--- a/bank/sheba.go
+++ b/bank/sheba.go
@@ -11,6 +11,11 @@ type ShebaCode struct {
 	Code string
 }
 
+var (
+	ErrIncorrectIBAN = errors.New("IBAN is not correct")
+	ErrInvalidIBAN = errors.New("IBAN has incorrect check digits")
+)
+
 func (s ShebaCode) IsSheba() shebaResultHash {
 	shebaCode := s.Code
 
@@ -34,11 +39,11 @@ func iso7064Mod97_10(iban string) error {
 	modVal := new(big.Int).SetInt64(97)
 	bigVal, success := new(big.Int).SetString(remainder, 10)
 	if !success {
-		return errors.New("IBAN has incorrect check digits")
+		return ErrInvalidIBAN
 	}
 	resVal := new(big.Int).Mod(bigVal, modVal)
 	if resVal.Int64() != 1 {
-		return errors.New("IBAN is not correct")
+		return ErrIncorrectIBAN
 	}
 	return nil
 }


### PR DESCRIPTION
this is good for better error handling

example:
```go
if _, err := bank.CardInfo("abcd"); errors.Is(err, bank.ErrInvalidCard) {
     fmt.Println("your card hasn't valid format, try again...")
}
```